### PR TITLE
Feat: #4 Added 'markdown', 'call' and 'email'

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ action:
         click: https://www.home-assistant.io/
         actions: [list_of_actions]
         icon: https://placekitten.com/400/300
+        delay: 10s
+        markdown: True
+        call: "+324793245"
+        email: "support@home-assistant.io"
 ```
 
 ### License

--- a/custom_components/ntfy/notify.py
+++ b/custom_components/ntfy/notify.py
@@ -68,16 +68,20 @@ class HassAgentNotificationService(BaseNotificationService):
         icon = data.get('icon') or self._icon or ""
 
         payload = {
-            'topic': topic,
-            'message': message,
-            'title': title,
-            'tags': data.get('tags', []),
-            'priority': data.get('priority', 3),
-            'attach': data.get('attach', "") or data.get('image', ""),
-            'filename': data.get('filename', ""),
-            'click': data.get('click', "") or data.get('click_url', ""),
-            'actions': data.get('actions', []),
-            'icon': icon,
+            "topic": topic,
+            "message": message,
+            "title": title,
+            "tags": data.get("tags", []),
+            "priority": data.get("priority", 3),
+            "attach": data.get("attach", "") or data.get("image", ""),
+            "filename": data.get("filename", ""),
+            "click": data.get("click", "") or data.get("click_url", ""),
+            "actions": data.get("actions", []),
+            "icon": icon,
+            "markdown": "markdown" in data,
+            "delay": data.get("delay", ""),
+            "email": data.get("email", ""),
+            "call": data.get("call", ""),
         }
 
         _LOGGER.debug('Sending message to ntfy.sh: %s', payload)


### PR DESCRIPTION
As requested in #4, I added the fields that allow users to format messages as Markdown. In order to enable Markdown, a user just has to add __any__ string / boolean to the 'markdown' data field:

```
data:
  markdown: Yes
```

I implemented it this way so that we don't have to deal with validating the input.